### PR TITLE
Remove extraneous Player.userId column

### DIFF
--- a/server/src/games/entities.ts
+++ b/server/src/games/entities.ts
@@ -47,9 +47,6 @@ export class Player extends BaseEntity {
   @ManyToOne(_ => Game, game => game.players)
   game: Game
 
-  @Column()
-  userId: number
-
   @Column('char', {length: 1})
   symbol: Symbol
 }


### PR DESCRIPTION
Rumour has it (students told me) TypeORM tries to create 2 `user_id` columns for the `players` table if we leave this in.

This seems [in line with the docs](http://typeorm.io/#/many-to-one-one-to-many-relations) where they have this example:

```ts
import {Entity, PrimaryGeneratedColumn, Column, ManyToOne} from "typeorm";
import {User} from "./User";

@Entity()
export class Photo {

    @PrimaryGeneratedColumn()
    id: number;

    @Column()
    url: string;

    @ManyToOne(type => User, user => user.photos)
    user: User;

}
```

As you can see, the Photo model does not have a `userId` column defined aside from the `@ManyToOne` relation definition.